### PR TITLE
download read and admin added to SADCO scopes

### DIFF
--- a/sadco/const/__init__.py
+++ b/sadco/const/__init__.py
@@ -45,3 +45,5 @@ class SADCOScope(str, Enum):
     WAVES_DOWNLOAD = 'sadco.waves:download'
     UTR_DOWNLOAD = 'sadco.utr:download'
     VOS_DOWNLOAD = 'sadco.vos:download'
+    DOWNLOAD_READ = 'sadco.download:read'
+    DOWNLOAD_ADMIN = 'sadco.download:admin'


### PR DESCRIPTION
The two scopes: 'download read' and 'download admin' have been added to the SADCO const file. 