### PR TITLE
SADCO Client ID added to identity config

### DIFF
--- a/odp/config/odp.py
+++ b/odp/config/odp.py
@@ -58,7 +58,8 @@ class ODPIdentityConfig(BaseConfig):
         env_prefix = 'ODP_IDENTITY_'
 
     FLASK_SECRET: str  # Flask secret key
-    NCCRD_CLIENT_ID: str = None  # OAuth2 client ID that will trigger NCCRD UI branding
+    NCCRD_CLIENT_ID: str = None # OAuth2 client ID that will trigger NCCRD UI branding
+    SADCO_CLIENT_ID: str = None # OAuth2 client ID that will trigger SADCO UI branding
 
 
 class ODPMailConfig(BaseConfig):


### PR DESCRIPTION
SADCO Client ID added to the ODP Identity Config

Issue: [#35](https://github.com/SAEON/odp-server/issues/35)