### PR TITLE
Fix expired token not being set inside loop

### DIFF
--- a/odp/lib/client.py
+++ b/odp/lib/client.py
@@ -146,10 +146,10 @@ class ODPClient(ODPBaseClient):
             params: dict,
             headers: dict,
     ) -> requests.Response:
-        headers |= {
-            'Authorization': 'Bearer ' + self.token['access_token']
-        }
         for _ in range(2):
+            headers |= {
+                'Authorization': 'Bearer ' + self.token['access_token']
+            }
             response = requests.request(
                 method=method,
                 url=url,


### PR DESCRIPTION
Moved the setting of the header on a ODPClient Request to inside the loop so that if a token has expired it gets a new token and tries again.