### PR TITLE
Fix DownloadAuditModel and add MetadataBundleRequest model

### DIFF
--- a/odp/api/models/__init__.py
+++ b/odp/api/models/__init__.py
@@ -32,5 +32,5 @@ from .user import UserModel, UserModelIn
 from .vocabulary import VocabularyModel, VocabularyTermModel, VocabularyTermModelIn
 from .download import (DownloadAuditCreateModel, DownloadAuditModel,
                        DownloadAuditResponse, DownloadStatsModel, MetadataBundleRecord,
-                       MetadataBundleResponse, UserData)
+                       MetadataBundleRequest, MetadataBundleResponse, UserData)
 from .pdf import MetadataFormatRequest, PDFGenerationErrorResponse, PDFGenerationRequest

--- a/odp/api/models/download.py
+++ b/odp/api/models/download.py
@@ -41,6 +41,7 @@ class DownloadAuditModel(BaseModel):
     ip_address: Optional[str] = Field(default=None, description="IP address of the requester")
     doi: Optional[str] = Field(default=None, description="DOI of the downloaded record (single_record type)")
     record_ids: list[str] = Field(default=[], description="List of record IDs included in the download")
+    catalog_url: Optional[str] = Field(default=None, description="Base URL of the catalog that initiated the download")
 
 
 class OrganisationStats(BaseModel):

--- a/odp/api/models/download.py
+++ b/odp/api/models/download.py
@@ -77,6 +77,14 @@ class DownloadStatsModel(BaseModel):
     daily_downloads: list[DailyDownloadStats] = Field(..., description="Daily download breakdown")
 
 
+class MetadataBundleRequest(BaseModel):
+    record_ids: list[str]
+    user_data: UserData
+    client_ip: Optional[str] = None
+    user_agent: Optional[str] = None
+    referer: Optional[str] = None
+
+
 class MetadataBundleRecord(BaseModel):
     folder_name: str
     metadata_pdf: str               # base64-encoded PDF bytes

--- a/odp/api/models/download.py
+++ b/odp/api/models/download.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, Field
 
 
 class UserData(BaseModel):
@@ -34,7 +34,7 @@ class DownloadAuditModel(BaseModel):
     id: int = Field(..., description="Audit record ID")
     timestamp: str = Field(..., description="ISO 8601 timestamp of the download")
     name: Optional[str] = Field(default=None, description="Name of the user who downloaded")
-    email: Optional[EmailStr] = Field(default=None, description="Email of the user who downloaded")
+    email: Optional[str] = Field(default=None, description="Email of the user who downloaded")
     organisation: Optional[str] = Field(default=None, description="Organisation of the user")
     download_type: Optional[str] = Field(default=None, description="Type of download: single_record or zip_bundle")
     success: bool = Field(..., description="Whether the download succeeded")


### PR DESCRIPTION
Added catalog_url as an optional field to DownloadAuditModel so the catalog base URL stored in the audit meta is exposed through the API. Changed the email field from EmailStr to plain str to prevent 500 errors when reading historical audit rows that have non-standard email values. Added a MetadataBundleRequest model that wraps record_ids, user_data, client_ip, user_agent, and referer into a single request body this is needed because FastAPI was treating those simple fields as query parameters instead of reading them from the JSON body. Merge this before odp-server and odp-admin.

